### PR TITLE
Opt into using Nodejs v24 in our workflows before GitHub deprecates N…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           CASSANDRA_HOST: cassandra
 
     env:
+      # Let's try opting into use of Nodejs v24; see:
+      #  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+      # GitHub runners still causing problems with NodeJS v20; see:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
       CASSANDRA_HOST: cassandra
 
     strategy:
@@ -38,13 +43,13 @@ jobs:
 
     steps:
       - name: Checkout ProFTPD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: proftpd/proftpd
           path: proftpd
 
       - name: Checkout module source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: proftpd-mod_sql_cassandra
 
@@ -152,9 +157,9 @@ jobs:
           # for cqlsh
           apt-get install -y curl software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
-          apt-get install -y python3.9 python3.9-venv
+          apt-get install -y python3.10 python3.10-venv
           curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          python3.9 get-pip.py
+          python3.10 get-pip.py
           pip3 --version
           pip3 install cqlsh
           cqlsh --version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      # Let's try opting into use of Nodejs v24; see:
+      #  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+      # GitHub runners still causing problems with NodeJS v20; see:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     strategy:
       fail-fast: true
       matrix:
@@ -31,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout ProFTPD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: proftpd/proftpd
 
       - name: Checkout mod_sql_cassandra
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: proftpd-mod_sql_cassandra
 


### PR DESCRIPTION
…odejs v20.